### PR TITLE
chore: replace em and en dashes with colons or plain hyphens

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -42,8 +42,8 @@ from pypulsepal import PulsePal
 | `set_resting_voltage(channel, voltage)` | Set `restingVoltage` on one channel |
 | `set_fixed_voltage(channel, voltage)` | Set immediate DC voltage outside pulse train |
 | `set_continuous(channel, state)` | Start (1) or stop (0) continuous output on a channel |
-| `set_logic(channel, level)` | Set digital logic level — model 2 only |
-| `get_logic(channel)` | Read digital logic level — model 2 only |
+| `set_logic(channel, level)` | Set digital logic level: model 2 only |
+| `get_logic(channel)` | Read digital logic level: model 2 only |
 
 ### Triggering
 
@@ -66,10 +66,10 @@ from pypulsepal import PulsePal
 |---|---|
 | `save_config(path)` | Save in-memory config to JSON or YAML |
 | `load_config(path)` | Load config from JSON or YAML and apply in memory |
-| `from_config(config, serial_port)` | Class method — connect and apply a `PulsePalConfig` |
+| `from_config(config, serial_port)` | Class method: connect and apply a `PulsePalConfig` |
 | `save_settings()` | Send disconnect opcode to persist params on device |
-| `save_to_sd(filename)` | Save RAM params to SD card — model 2 only |
-| `read_sd_params()` | Read SD card params as dict — model 2 only |
+| `save_to_sd(filename)` | Save RAM params to SD card: model 2 only |
+| `read_sd_params()` | Read SD card params as dict: model 2 only |
 | `reset_to_defaults()` | Reset all configs to defaults and sync to device |
 
 ---
@@ -80,7 +80,7 @@ from pypulsepal import PulsePal
 from pypulsepal.models import ChannelConfig, TriggerConfig, PulsePalConfig
 ```
 
-`PulsePalConfig` uses **1-indexed integer keys** for channels and triggers — `channels[1]` through `channels[4]`, `triggers[1]` through `triggers[2]`. String keys from JSON (`"1"`, `"2"`, …) are coerced to integers automatically.
+`PulsePalConfig` uses **1-indexed integer keys** for channels and triggers: `channels[1]` through `channels[4]`, `triggers[1]` through `triggers[2]`. String keys from JSON (`"1"`, `"2"`, …) are coerced to integers automatically.
 
 See [Concepts](concepts.md) for field-level documentation.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -31,7 +31,7 @@ cfg.phase1Voltage = 15.0       # raises ValidationError
 
 | Field | Type | Default | Unit | Notes |
 |---|---|---|---|---|
-| `isBiphasic` | bool | `False` | — | Biphasic pulse mode |
+| `isBiphasic` | bool | `False` |: | Biphasic pulse mode |
 | `phase1Voltage` | float | `5.0` | V | Range −10 to +10 |
 | `phase2Voltage` | float | `−5.0` | V | Range −10 to +10 |
 | `restingVoltage` | float | `0.0` | V | Range −10 to +10 |
@@ -43,11 +43,11 @@ cfg.phase1Voltage = 15.0       # raises ValidationError
 | `interBurstInterval` | float | `0.0` | s | 0 = bursts disabled |
 | `pulseTrainDuration` | float | `1.0` | s | Must be ≥ 0 |
 | `pulseTrainDelay` | float | `0.0` | s | Must be ≥ 0 |
-| `linkTriggerChannel1` | int | `1` | — | 0 or 1 |
-| `linkTriggerChannel2` | int | `0` | — | 0 or 1 |
-| `customTrainID` | int | `0` | — | 0 = train 1, 1 = train 2 |
-| `customTrainTarget` | int | `0` | — | 0 = pulse times, 1 = burst times |
-| `customTrainLoop` | int | `0` | — | 0 = once, 1 = loop |
+| `linkTriggerChannel1` | int | `1` |: | 0 or 1 |
+| `linkTriggerChannel2` | int | `0` |: | 0 or 1 |
+| `customTrainID` | int | `0` |: | 0 = train 1, 1 = train 2 |
+| `customTrainTarget` | int | `0` |: | 0 = pulse times, 1 = burst times |
+| `customTrainLoop` | int | `0` |: | 0 = once, 1 = loop |
 
 ## Trigger configuration
 
@@ -64,7 +64,7 @@ Each of the 2 trigger channels is described by a `TriggerConfig` model.
 ## PulsePalConfig
 
 `PulsePalConfig` holds the full device state: 4 channel configs and 2 trigger configs.
-Channels and triggers are keyed by their **1-indexed hardware number** (1–4 for channels, 1–2 for triggers), so there is never any ambiguity from list ordering.
+Channels and triggers are keyed by their **1-indexed hardware number** (1-4 for channels, 1-2 for triggers), so there is never any ambiguity from list ordering.
 
 ```python
 from pypulsepal.models import PulsePalConfig, ChannelConfig, TriggerConfig

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -34,7 +34,7 @@ On connection, `PulsePal` performs a handshake, reads the firmware version to de
 
 ## Basic pulse train
 
-Channels are **0-indexed** in the Python API (channels 0–3, triggers 0–1).
+Channels are **0-indexed** in the Python API (channels 0-3, triggers 0-1).
 
 ```python
 import time

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@
 
 Two methods upload the current in-memory channel and trigger configs to the device.
 
-### `sync_all_params()` — bulk upload (preferred)
+### `sync_all_params()`: bulk upload (preferred)
 
 Sends all parameters in a single serial write. Faster and less error-prone than iterating parameter by parameter.
 
@@ -14,7 +14,7 @@ pp.channel_configs[0].phase1Duration = 0.002
 pp.sync_all_params()
 ```
 
-### `upload_all()` — per-parameter upload
+### `upload_all()`: per-parameter upload
 
 Sends one serial round-trip per parameter. Use when you need to confirm each parameter individually, or for compatibility with older firmware.
 
@@ -22,7 +22,7 @@ Sends one serial round-trip per parameter. Use when you need to confirm each par
 pp.upload_all()
 ```
 
-### `program_one_param()` — single parameter update
+### `program_one_param()`: single parameter update
 
 Updates a single parameter on a single channel without uploading everything.
 
@@ -30,13 +30,13 @@ Updates a single parameter on a single channel without uploading everything.
 pp.program_one_param(channel=0, param_name="phase1Voltage", param_value=3.0)
 ```
 
-### `set_resting_voltage()` — convenience wrapper
+### `set_resting_voltage()`: convenience wrapper
 
 ```python
 pp.set_resting_voltage(channel=0, voltage=0.0)
 ```
 
-### `set_fixed_voltage()` — immediate DC output
+### `set_fixed_voltage()`: immediate DC output
 
 Sets a channel to a fixed DC voltage immediately, outside of any pulse train sequence.
 
@@ -46,13 +46,13 @@ pp.set_fixed_voltage(channel=0, voltage=3.3)
 
 ## Triggering channels
 
-### Software trigger — selected channels
+### Software trigger: selected channels
 
 ```python
 pp.trigger_selected_channels(channel_1=True, channel_3=True)
 ```
 
-### Software trigger — all channels
+### Software trigger: all channels
 
 ```python
 pp.trigger_all_channels()

--- a/src/pypulsepal/pulsepal.py
+++ b/src/pypulsepal/pulsepal.py
@@ -623,7 +623,7 @@ class PulsePal:
 
         Args:
             channel: 0-indexed output channel.
-            level: Logic level — 0 or 1.
+            level: Logic level: 0 or 1.
         """
         message = [
             self.encoded_opcode,
@@ -641,7 +641,7 @@ class PulsePal:
             channel: 0-indexed output channel.
 
         Returns:
-            Logic level — 0 or 1.
+            Logic level: 0 or 1.
         """
         message = [
             self.encoded_opcode,
@@ -693,7 +693,7 @@ class PulsePal:
     def save_settings(self) -> bool:
         """Send disconnect opcode (81) to save current params on device.
 
-        Firmware sends no ack byte for this opcode — confirmed on model 2 fw21.
+        Firmware sends no ack byte for this opcode: confirmed on model 2 fw21.
         Returns False if not connected or port is closed.
         """
         if self._arcom is None:
@@ -713,7 +713,7 @@ class PulsePal:
     def save_to_sd(self, filename: str = "default.pps") -> None:
         """Save current RAM params to SD card (opcode 90, op 1).
 
-        Firmware sends no ack byte — do not read confirmation.
+        Firmware sends no ack byte: do not read confirmation.
         A 100ms sleep is inserted to allow SD write to complete.
         """
         if self._arcom is None:
@@ -736,12 +736,12 @@ class PulsePal:
         Keys match ChannelConfig field names; 'triggerAddress' is firmware-only
         (4-element list of output channel link flags per trigger channel).
 
-        SD byte layout — per output channel ×4 (42 bytes each):
+        SD byte layout: per output channel ×4 (42 bytes each):
           8× uint32  phase1Duration, interPhaseInterval, phase2Duration,
                      interPulseInterval, burstDuration, interBurstInterval,
                      pulseTrainDuration, pulseTrainDelay  (firmware cycles ÷ 20000 = s)
           1× uint8   isBiphasic
-          3× uint16  phase1Voltage, phase2Voltage, restingVoltage  (0–65535 → ±10V)
+          3× uint16  phase1Voltage, phase2Voltage, restingVoltage  (0-65535 → ±10V)
           3× uint8   customTrainID, customTrainTarget, customTrainLoop
         Per trigger channel ×2 (5 bytes each):
           1× uint8   triggerMode


### PR DESCRIPTION
Remove all em dashes (U+2014) and en dashes (U+2013) from src/, docs/, and tests/ per sop/git_workflow.md writing style. Em dashes used as separators become colons; en dashes in numeric ranges become plain hyphens.