### PR TITLE
chore: remove Ruff badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # PyPulsePal
 
 [![PyPI](https://img.shields.io/pypi/v/pypulsepal.svg)](https://pypi.org/project/pypulsepal)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 Python API for the PulsePal open-source pulse train generator.
 


### PR DESCRIPTION
## Summary

- Removes the Ruff badge from README.md

SOP (`sop/build_system.md`) prohibits Ruff and Black badges. Only PyPI (if published) and DOI/Zenodo (if on Zenodo) badges are allowed.