### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewers for all changes.
+* @MurineShiftWork/msw-maintainers


### PR DESCRIPTION
Add a CODEOWNERS file routing review of all changes to @MurineShiftWork/msw-maintainers. Part of the governance/team-separation rollout (no branch protection applied yet).