### PR TITLE
chore(security): use project email, drop personal address

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # Changes here will be overwritten by Copier
 _commit: v0.8.5
 _src_path: gh:larsrollik/templatepy
-author_email: l.b.rollik@protonmail.com
+author_email: lars@rollik.me
 author_name: Lars B. Rollik
 github_repo: pypulsepal
 github_username: larsrollik

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@ Contributions are absolutely encouraged, for bug fixes, new features, etc.
 
 If you are not sure where to start, check out the [issues](https://github.com/larsrollik/pypulsepal/issues).
 
-Please get in touch via [email](mailto:L.B.Rollik@protonmail.com) for other queries.
+Please get in touch via [email](mailto:lars@rollik.me) for other queries.


### PR DESCRIPTION
Replaces the personal `*rollik@protonmail.com` address with the project address `lars@rollik.me` (CONTRIBUTING / .copier-answers / metadata). Flagged in SECURITY_SWEEP_2026-06-20.md. No logic change.