### PR TITLE
fix: use FLOAT32 in get_array (ArduinoTypes.FLOAT undefined)

### DIFF
--- a/src/pypulsepal/_arcom.py
+++ b/src/pypulsepal/_arcom.py
@@ -39,7 +39,7 @@ class ArduinoTypes:
             return ArduinoTypes.get_uint8_array(array)
         elif dtype == ArduinoTypes.UINT16:
             return ArduinoTypes.get_uint16_array(array)
-        elif dtype == ArduinoTypes.UINT32 or dtype == ArduinoTypes.FLOAT:
+        elif dtype == ArduinoTypes.UINT32 or dtype == ArduinoTypes.FLOAT32:
             return ArduinoTypes.get_uint32_array(array)
         else:
             return None


### PR DESCRIPTION
`ArduinoTypes` defines `FLOAT32`/`FLOAT64`, not `FLOAT`. So `dtype == ArduinoTypes.FLOAT` at `_arcom.py:42` raised `AttributeError` for any dtype that wasn't `UINT32` (the `==` short-circuits only when the UINT32 comparison is True). The 4-byte uint32 packing corresponds to `FLOAT32`, so use that. Found by the 2026-06-21 fleet sweep.