### PR TITLE
chore: correct license metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: "PyPulsePal: Python API for the PulsePal open-source pulse train generato
 version: "0.3.2"
 repository-code: https://github.com/murineshiftwork/pypulsepal
 url: https://murineshiftwork.github.io/pypulsepal/
-license: GPL-3.0
+license: BSD-3-Clause
 keywords:
   - neuroscience
   - pulse generator

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2021-present, Lars B. Rollik
+Copyright (c) 2022-present, Lars B. Rollik
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Corrects this package's licence metadata so the LICENSE file, CITATION.cff license field, and packaging classifiers consistently declare the correct licence and copyright year. No code changes; metadata only.