### PR TITLE
chore(ci): scope push trigger to main and add version test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
     tags-ignore: ["v*"]
   pull_request:
     branches: [main]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version
+
+
+def test_version_is_non_empty_string():
+    result = version("pypulsepal")
+    assert isinstance(result, str)
+    assert result


### PR DESCRIPTION
Modernize CI to the shared templatepy pattern.

## Changes
- ci.yml: restrict the push trigger to the main branch (was all branches). Node-24 pins, lint job, PR-only test matrix (3.12/3.13), and the ci gate are unchanged.
- tests/test_version.py: assert package version metadata resolves to a non-empty string.

## Left intact
- release.yml PyPI publish and id-token: write OIDC binding.
- uv.lock already gitignored.

## Verification
- uv sync --extra dev: ok
- uv run pre-commit run --all-files: pass
- uv run pytest: 138 passed